### PR TITLE
Link to an EPO page with a valid SSL certificate

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
   <tr>
     <td align="left" valign="bottom" id="sponsor">
       <p><a href="http://www.enlightenedperl.org" target="_blank" onclick="ga('send', 'event', 'Home', 'Ad Click', 'AdEpo');"></a>
-      <p>support us by <a href="https://members.enlightenedperl.org/" target="_blank" onclick="ga('send', 'event', 'Home', 'Ad Click', 'AdEpoMem');">becoming an EPO member</a>
+      <p>support us by <a href="https://www.enlightenedperl.org/membership/" target="_blank" onclick="ga('send', 'event', 'Home', 'Ad Click', 'AdEpoMem');">becoming an EPO member</a>
     </td>
     <td align="right" valign="top">
       <ul class="downloads">


### PR DESCRIPTION
When following the link, you get to a page with an invalid SSL certificate. I've linked to what seems a better place.