### PR TITLE
Remove the "Support us by becoming an EPO member" link.

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,9 +44,6 @@
             You can find here release notes and other details.
         </div>
     </div>
-    <div class="sponsor">
-        <p>Support us by <a href="https://www.enlightenedperl.org/membership/" target="_blank" onclick="ga('send', 'event', 'Home', 'Ad Click', 'AdEpoMem');">becoming an EPO member</a>.</p>
-    </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Since EnlightenedPerl has closed its doors, we think we can remove this link at this time.

Thank you to the EPO for all of the support through now.